### PR TITLE
AB#662 Add option to disable TLS for webserver

### DIFF
--- a/emojivoto-web/web/web.go
+++ b/emojivoto-web/web/web.go
@@ -423,3 +423,34 @@ func StartServer(webPort, webpackDevServer, indexBundle string, emojiServiceClie
 		panic(err)
 	}
 }
+
+func StartServerNoTLS(webPort, webpackDevServer, indexBundle string, emojiServiceClient pb.EmojiServiceClient, votingClient pb.VotingServiceClient) {
+	webApp := &WebApp{
+		emojiServiceClient:  emojiServiceClient,
+		votingServiceClient: votingClient,
+		indexBundle:         indexBundle,
+		webpackDevServer:    webpackDevServer,
+	}
+
+	log.Printf("Starting web server on WEB_PORT=[%s]", webPort)
+	handle("/", webApp.indexHandler)
+	handle("/leaderboard", webApp.indexHandler)
+	handle("/js", webApp.jsHandler)
+	handle("/img/favicon.ico", webApp.faviconHandler)
+	handle("/api/list", webApp.listEmojiHandler)
+	handle("/api/vote", webApp.voteEmojiHandler)
+	handle("/api/leaderboard", webApp.leaderboardHandler)
+
+	// TODO: make static assets dir configurable
+	http.Handle("/dist/", http.StripPrefix("/dist/", http.FileServer(http.Dir("dist"))))
+
+	server := http.Server{
+		Addr:    fmt.Sprintf(":%s", webPort),
+		Handler: nil,
+	}
+
+	err := server.ListenAndServe()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/kubernetes/nosgx_values.yaml
+++ b/kubernetes/nosgx_values.yaml
@@ -9,6 +9,7 @@ simulation:
 web:
   image: ghcr.io/edgelesssys/emojivoto/web
   imageVersion: v0.2.0
+  tlsServer: enabled
 
 emoji:
   image: ghcr.io/edgelesssys/emojivoto/emoji-svc

--- a/kubernetes/sgx_values.yaml
+++ b/kubernetes/sgx_values.yaml
@@ -20,6 +20,7 @@ simulation:
 web:
   image: ghcr.io/edgelesssys/emojivoto/web
   imageVersion: v0.2.0
+  tlsServer: enabled
 
 emoji:
   image: ghcr.io/edgelesssys/emojivoto/emoji-svc

--- a/kubernetes/templates/web.yml
+++ b/kubernetes/templates/web.yml
@@ -42,6 +42,8 @@ spec:
             configMapKeyRef:
               name: oe-config
               key: OE_SIMULATION
+        - name: TLS_SERVER
+          value: {{ .Values.web.tlsServer }}
         image: {{ .Values.web.image }}:{{ .Values.web.imageVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: web-svc


### PR DESCRIPTION
Adds the option to disable tls for the webserver. Configurable over env variable TLS_SERVER which can be set using the helm charts.