### PR TITLE
Update Dockerfile and image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@
 FROM alpine/git:latest AS pull
 RUN git clone https://github.com/edgelesssys/emojivoto.git /emojivoto
 
-FROM ghcr.io/edgelesssys/ego-deploy:nightly AS emoji_base
+FROM ghcr.io/edgelesssys/ego-deploy:latest AS emoji_base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl dnsutils iptables jq nghttp2 && \
     apt clean && \
     apt autoclean
 
-FROM ghcr.io/edgelesssys/ego-dev:nightly AS emoji_build
+FROM ghcr.io/edgelesssys/ego-dev:latest AS emoji_build
 RUN go get github.com/golang/protobuf/protoc-gen-go && \
     go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
 WORKDIR /node

--- a/kubernetes/nosgx_values.yaml
+++ b/kubernetes/nosgx_values.yaml
@@ -8,13 +8,13 @@ simulation:
 
 web:
   image: ghcr.io/edgelesssys/emojivoto/web
-  imageVersion: v0.2.0
+  imageVersion: v0.3.0
   tlsServer: enabled
 
 emoji:
   image: ghcr.io/edgelesssys/emojivoto/emoji-svc
-  imageVersion: v0.2.0
+  imageVersion: v0.3.0
 
 voting:
   image: ghcr.io/edgelesssys/emojivoto/voting-svc
-  imageVersion: v0.2.0
+  imageVersion: v0.3.0


### PR DESCRIPTION
Updates Dockerfile to use latest images for building and deploying instead of nightly.
Also update helm nosgx_values.yaml to use emojivoto:v0.3.0