### PR TITLE
AB#1302 Remove usage of namespace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,38 +183,18 @@ Confidential emojivoto is build as a confidential computing application:
         marblerun manifest set tools/manifest.json $MARBLERUN --insecure --recoverydata recovery.json
         ```
 
-1. Create and annotate emojivoto namespace for auto-injection
-
-    Create namespace
-
-    ```bash
-    kubectl create namespace emojivoto
-    ```
-
-    * Annotate the namespace if you're running minikube on a machine that support SGX1+FLC
-
-        ```bash
-        marblerun namespace add emojivoto
-        ```
-
-    * Otherwise
-
-        ```bash
-        marblerun namespace add emojivoto --no-sgx-injection
-        ```
-
 1. Deploy emojivoto using [helm](https://helm.sh/docs/intro/install/)
 
     * If you're running minikube on a machine that support SGX1+FLC
 
     ```bash
-    helm install -f ./kubernetes/sgx_values.yaml emojivoto ./kubernetes -n emojivoto
+    helm install -f ./kubernetes/sgx_values.yaml emojivoto ./kubernetes --create-namespace -n emojivoto
     ```
 
     * Otherwise
 
     ```bash
-    helm install -f ./kubernetes/nosgx_values.yaml emojivoto ./kubernetes -n emojivoto
+    helm install -f ./kubernetes/nosgx_values.yaml emojivoto ./kubernetes --create-namespace -n emojivoto
     ```
 
     You can check with `kubectl get pods -n emojivoto` that all pods are running.

--- a/kubernetes/nosgx_values.yaml
+++ b/kubernetes/nosgx_values.yaml
@@ -6,6 +6,8 @@ imagePullPolicy: IfNotPresent
 simulation:
   OE_SIMULATION: "1"
 
+resourceInjection: "disabled"
+
 web:
   image: ghcr.io/edgelesssys/emojivoto/web
   imageVersion: v0.5.0

--- a/kubernetes/sgx_values.yaml
+++ b/kubernetes/sgx_values.yaml
@@ -10,6 +10,8 @@ resources:
 simulation:
   OE_SIMULATION: "0"
 
+resourceInjection: "enabled"
+
 web:
   image: ghcr.io/edgelesssys/emojivoto/web
   imageVersion: v0.5.0

--- a/kubernetes/templates/emoji.yml
+++ b/kubernetes/templates/emoji.yml
@@ -26,6 +26,7 @@ spec:
         app: emoji-svc
         version: v1
         marblerun/marbletype: emoji-svc
+        marblerun/resource-injection: {{ .Values.resourceInjection }}
     spec:
       serviceAccountName: emoji
       containers:

--- a/kubernetes/templates/voting.yml
+++ b/kubernetes/templates/voting.yml
@@ -26,6 +26,7 @@ spec:
         app: voting-svc
         version: v1
         marblerun/marbletype: voting-svc
+        marblerun/resource-injection: {{ .Values.resourceInjection }}
     spec:
       serviceAccountName: voting
       containers:

--- a/kubernetes/templates/web.yml
+++ b/kubernetes/templates/web.yml
@@ -26,6 +26,7 @@ spec:
         app: web-svc
         version: v1
         marblerun/marbletype: web
+        marblerun/resource-injection: {{ .Values.resourceInjection }}
     spec:
       serviceAccountName: web
       containers:


### PR DESCRIPTION
Removes usage of `marblerun namespace` and adds the `marblerun/resource-injection=disabled` label for simulation mode.

**Do not merge until we have a release for MarbleRun with these changes!**